### PR TITLE
Moved CLA text to a contributing file and minor edit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Commits and pull requests to repositories within FINOS such as this one will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS OR who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [FINOS cla-bot tool](https://github.com/finos-fdx/cla-bot). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+Commits and pull requests to repositories within FINOS such as this one will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS, or who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [FINOS cla-bot tool](https://github.com/finos-fdx/cla-bot). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
 
 Need an ICLA? Unsure if you are covered under an existing CCLA? Email help@finos.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Commits and pull requests to repositories within FINOS such as this one will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS OR who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [FINOS cla-bot tool](https://github.com/finos-fdx/cla-bot). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+
+Need an ICLA? Unsure if you are covered under an existing CCLA? Email help@finos.org

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ There are three sets of definition files (authenticator, agent and pod) and each
 
 You can paste the contents of these files into [Swagger Editor](http://editor.swagger.io/), from which you can generate client code.
 
-NOTE: Commits and pull requests to repositories within FINOS such as this one will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS OR who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the FINOS Clabot tool. Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+## Contribution
 
-Need an ICLA? Unsure if you are covered under an existing CCLA? Email help@finos.org
+Contributions to this project must be covered by a CLA as outlined in the [Contribution guidelines for this project](CONTRIBUTING.md).


### PR DESCRIPTION
@brooklynrob I saw your email about CLAs via the FINOS mailing list. I've made a few small changes to the contributing text (FINOS OR looked like some sort of new organization or group), and moved the text to a CONTRIBUTING file, which gives greater visibility as per the [GitHub guidelines](https://help.github.com/en/articles/setting-guidelines-for-repository-contributors).