### PR TITLE
(rc-current-r55) Fix: v1/message/{id} endpoint swagger definition to mark keyManagerToken as a required param

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -442,7 +442,7 @@ paths:
           - name: keyManagerToken
             description: Key Manager authentication token.
             in: header
-            required: false
+            required: true
             type: string
           - name: id
             description: Message ID as a URL-safe string

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -442,7 +442,7 @@ paths:
           - name: keyManagerToken
             description: Key Manager authentication token.
             in: header
-            required: false
+            required: true
             type: string
           - name: id
             description: Message ID as a URL-safe string


### PR DESCRIPTION
(Reference PR: https://github.com/symphonyoss/symphony-api-spec/pull/39)

The keyManagerToken attribute was always required, as it is not OBO-enabled. Currently the application returns a 400 Bad Request status when the attribute is not provided.