### PR TITLE
APP-2845: Renamed tags in authenticator api to avoid clashes over several files

### DIFF
--- a/authenticator/authenticator-api-public.yaml
+++ b/authenticator/authenticator-api-public.yaml
@@ -27,7 +27,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -56,7 +56,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       parameters:
         - name: authRequest
           description: application generated token
@@ -93,7 +93,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Pod
+        - CertificatePod
       responses:
         '200':
           description: OK
@@ -116,7 +116,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -152,7 +152,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -191,7 +191,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -227,7 +227,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.


### PR DESCRIPTION
Renamed tags in authenticator api to avoid generated classes to be overwritten. 
Having same tag "Authentication" in both https://github.com/symphonyoss/symphony-api-spec/blob/master/authenticator/authenticator-api-public.yaml and https://github.com/symphonyoss/symphony-api-spec/blob/master/login/login-api-public.yaml resulted in one single class AuthenticationApi reflecting only login-api-public.yaml
This is needed in scope of APP-2845