### PR TITLE
Add FINOS Active Badge to Symphony API Spec project README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
+
 # symphony-api-spec
 
 This repository will contain the Swagger API definition files for the Symphony REST API. These files were previously available from Symphony LLC at https://rest-api.symphony.com/docs/rest-api-specification.  Versions of these files prior to release 1.46 can still be found there.


### PR DESCRIPTION
## Description
This pull request adds the FINOS `Active` project badge to the project's [README.md](https://github.com/symphonyoss/symphony-api-spec/blob/master/README.md) to reflect the `Active` status of the project within the FINOS foundation.

### FINOS Active Badge
[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)

### Markdown Added
```
[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
```

