### PR TITLE
Renamed tags in authenticator api to clashes across several files

### DIFF
--- a/authenticator/authenticator-api-public.yaml
+++ b/authenticator/authenticator-api-public.yaml
@@ -27,7 +27,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -56,7 +56,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       parameters:
         - name: authRequest
           description: application generated token
@@ -93,7 +93,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Pod
+        - CertificatePod
       responses:
         '200':
           description: OK
@@ -116,7 +116,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -152,7 +152,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -191,7 +191,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.
@@ -227,7 +227,7 @@ paths:
       produces:
         - application/json
       tags:
-        - Authentication
+        - CertificateAuthentication
       responses:
         '200':
           description: OK.


### PR DESCRIPTION
Apply back changes done during the following PR https://github.com/symphonyoss/symphony-api-spec/pull/68