### PR TITLE
PLAT-10435 - Change tag name for /roles/list in Swagger spec

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -3995,7 +3995,7 @@ paths:
           required: true
           type: string
       tags:
-        - System
+        - User
       responses:
         '200':
           description: Success

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -3995,7 +3995,7 @@ paths:
           required: true
           type: string
       tags:
-        - System
+        - User
       responses:
         '200':
           description: Success


### PR DESCRIPTION
[PLAT-10435](https://perzoinc.atlassian.net/browse/PLAT-10435) : BDK2.0 Java - Change tag name for /roles/list in Swagger spec

The pod-api-public and pod-api-public-deprecated were mentioning "System" as a tag for "/roles/list" endpoint. This tag being duplicated in agent public api, it is overwritten in symphony-api-client and only agent's system api class is generated.

In this PR, the tag for "/roles/list" is changed to match the same as "/roles/add" and "/roles/remove".