### PR TITLE
Backport PLAT-10436 changing roleDetails definition to support string ids without Long format constraint.

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6635,7 +6635,6 @@ definitions:
     properties:
       id:
         type: string
-        format: long
       name:
         type: string
       userTypes:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5481,7 +5481,6 @@ definitions:
     properties:
       id:
         type: string
-        format: long
       name:
         type: string
       userTypes:


### PR DESCRIPTION
Backport PLAT-10436 changing roleDetails definition to support string ids without Long format constraint.