### PR TITLE
Backport PLAT-10436 : Change roleDetails definition to support string ids without Long format constraint 

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6624,7 +6624,6 @@ definitions:
     properties:
       id:
         type: string
-        format: long
       name:
         type: string
       userTypes:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5545,7 +5545,6 @@ definitions:
     properties:
       id:
         type: string
-        format: long
       name:
         type: string
       userTypes:


### PR DESCRIPTION
**PLAT-10436 :** Change roleDetails definition to support string without Long format constraint.

RoleDetails was defined as a string in Long format which prevent us to create roles as defined in [Roles Object documentation](https://developers.symphony.com/restapi/reference#roles-object). This is changed to support Strings without Long format constraint.