### PR TITLE
PLAT-10651: Wrong format for UserFilter.role field in specification

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6447,7 +6447,8 @@ definitions:
     properties:
       role:
         type: string
-        format: long
+        description: The user role
+        example: "INDIVIDUAL"
       feature:
         type: string
       status:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5293,7 +5293,8 @@ definitions:
     properties:
       role:
         type: string
-        format: long
+        description: The user role
+        example: "INDIVIDUAL"
       feature:
         type: string
       status:


### PR DESCRIPTION
The role was set as a string with long format whereas it is just a
string. This is preventing clients using generated code to properly
work.

Change done in SBE, backporting it here for next release.

Related to https://github.com/SymphonyOSF/SBE/pull/21998