### PR TITLE
PLAT-10688: Made Pagination.cursors.after optional

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -7551,7 +7551,6 @@ definitions:
         type: object
         required:
           - before
-          - after
         properties:
           before:
             type: string

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -6397,7 +6397,6 @@ definitions:
         type: object
         required:
           - before
-          - after
         properties:
           before:
             type: string


### PR DESCRIPTION
Field Pagination.cursors.after was not aligned with actual behaviour where it is optional (field is not sent back when we are at the last page of results).
This was causing the Python BDK2.0 to fail when receiving a response without the after field.

Opened https://github.com/SymphonyOSF/SBE/pull/22009