### PR TITLE
PLAT-10555 - Making the product sku property optional

### DIFF
--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5349,7 +5349,6 @@ definitions:
     type: object
     required:
       - name
-      - sku
       - type
       - subscribed
     properties:


### PR DESCRIPTION
The sku property is not required in a default product but only in premium ones.
In the case of a premium product, the verification of this property is Done in AppUtil.java so it shouldn't be a breaking change.