### PR TITLE
PLAT-10688: Made Pagination.cursors.after optional

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -7550,7 +7550,6 @@ definitions:
         type: object
         required:
           - before
-          - after
         properties:
           before:
             type: string

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -6395,7 +6395,6 @@ definitions:
         type: object
         required:
           - before
-          - after
         properties:
           before:
             type: string


### PR DESCRIPTION
After version 20.12 has been released, some changes that were made after 20.12 release in SBE have been overwritten, adding them back.

Normally this should not happen since we should do changes in SBE/Agent repo and then start using them after a release. If we want to use them early them we have to do the changes in this repo too

(cherry picked from commit 6ab8195b5d7b2b154b340effd596ad2aaad5521f)