### PR TITLE
PLAT-10714 Fix UserAppEntitlementsPatchList reference paths

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -3087,30 +3087,30 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/UserAppEntitlementsPatchList'
+            $ref: '#/definitions/UserAppEntitlementsPatchList'
       tags:
         - AppEntitlement
       responses:
         '200':
           description: Success
           schema:
-            $ref: '#/UserAppEntitlementList'
+            $ref: '#/definitions/UserAppEntitlementList'
         '400':
           description: 'Client error, see response body for further details.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '500':
           description: 'Server error, see response body for further details.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
   '/v1/admin/user/{uid}/avatar':
     get:
       summary: Get the URL of the avatar of a particular user

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -3087,30 +3087,30 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/UserAppEntitlementsPatchList'
+            $ref: '#/definitions/UserAppEntitlementsPatchList'
       tags:
         - AppEntitlement
       responses:
         '200':
           description: Success
           schema:
-            $ref: '#/UserAppEntitlementList'
+            $ref: '#/definitions/UserAppEntitlementList'
         '400':
           description: 'Client error, see response body for further details.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
         '500':
           description: 'Server error, see response body for further details.'
           schema:
-            $ref: '#/Error'
+            $ref: '#/definitions/Error'
   '/v1/admin/user/{uid}/avatar':
     get:
       summary: Get the URL of the avatar of a particular user


### PR DESCRIPTION
When trying to generate python BDK code, we get an error related to a non found reference. It seems the UserAppEntitlementsPatchList didn't have the full reference path.